### PR TITLE
Implement dataset loaders

### DIFF
--- a/Halogen.hpp
+++ b/Halogen.hpp
@@ -5,6 +5,8 @@
 #include <numeric>
 #include <filesystem>
 #include <fstream>
+#include <sstream>
+#include <stdexcept>
 #include <cmath>
 namespace Halogen {
     class Node {
@@ -242,7 +244,69 @@ namespace Halogen {
         }
     };
 
-    Tensor<float> read_mnist_images(const std::string& path, int limit=-1){
+    namespace detail {
+        inline uint32_t read_be32(std::ifstream& f){
+            uint32_t v=0; f.read(reinterpret_cast<char*>(&v),4);
+            return ((v>>24)&0xff) | ((v>>8)&0xff00) | ((v<<8)&0xff0000) | (v<<24);
+        }
+    }
 
+    Tensor<float> read_mnist_images(const std::string& path, int limit=-1){
+        std::ifstream file(path, std::ios::binary);
+        if(!file.is_open()) throw std::runtime_error("unable to open "+path);
+        uint32_t magic = detail::read_be32(file);
+        if(magic != 2051) throw std::runtime_error("invalid mnist image file");
+        uint32_t count = detail::read_be32(file);
+        uint32_t rows  = detail::read_be32(file);
+        uint32_t cols  = detail::read_be32(file);
+        if(limit>0 && static_cast<uint32_t>(limit) < count) count = limit;
+        Tensor<float> out({static_cast<int>(count), static_cast<int>(rows*cols)});
+        std::vector<uint8_t> buffer(rows*cols);
+        for(uint32_t i=0;i<count;++i){
+            file.read(reinterpret_cast<char*>(buffer.data()), buffer.size());
+            for(size_t j=0;j<buffer.size();++j)
+                out({static_cast<int>(i), static_cast<int>(j)}) = buffer[j]/255.f;
+        }
+        return out;
+    }
+
+    Tensor<float> read_mnist_labels(const std::string& path, int limit=-1){
+        std::ifstream file(path, std::ios::binary);
+        if(!file.is_open()) throw std::runtime_error("unable to open "+path);
+        uint32_t magic = detail::read_be32(file);
+        if(magic != 2049) throw std::runtime_error("invalid mnist label file");
+        uint32_t count = detail::read_be32(file);
+        if(limit>0 && static_cast<uint32_t>(limit) < count) count = limit;
+        Tensor<float> out({static_cast<int>(count)});
+        for(uint32_t i=0;i<count;++i){
+            uint8_t v; file.read(reinterpret_cast<char*>(&v),1);
+            out({static_cast<int>(i)}) = static_cast<float>(v);
+        }
+        return out;
+    }
+
+    Tensor<float> read_csv(const std::string& path, char delim=',', bool header=false){
+        std::ifstream file(path);
+        if(!file.is_open()) throw std::runtime_error("unable to open "+path);
+        std::vector<std::vector<float>> rows;
+        std::string line;
+        if(header) std::getline(file,line);
+        while(std::getline(file,line)){
+            std::vector<float> row;
+            std::stringstream ss(line);
+            std::string cell;
+            while(std::getline(ss,cell,delim)){
+                if(!cell.empty()) row.push_back(std::stof(cell));
+            }
+            if(!row.empty()) rows.push_back(row);
+        }
+        if(rows.empty()) return Tensor<float>();
+        int n=rows.size();
+        int m=rows[0].size();
+        Tensor<float> out({n,m});
+        for(int i=0;i<n;i++)
+            for(int j=0;j<m;j++)
+                out({i,j}) = rows[i][j];
+        return out;
     }
 }


### PR DESCRIPTION
## Summary
- extend include list in `Halogen.hpp`
- add MNIST image & label readers
- add generic CSV loader

## Testing
- `cmake -B build && cmake --build build` *(fails: CMake 4.0 required)*
- `g++ -std=c++20 -o halogen main.cpp`
- `./halogen` *(fails: aborts due to runtime error)*

------
https://chatgpt.com/codex/tasks/task_e_684bbc1239988331b61d69fa90276af8